### PR TITLE
Fix(#27) Open up plots on clicking on test result link

### DIFF
--- a/dashboard/core/bots/authentication_classes.py
+++ b/dashboard/core/bots/authentication_classes.py
@@ -2,9 +2,10 @@ from rest_framework import authentication, exceptions
 from dashboard.core.bots.models import Bot
 
 
-
 class BotAuthentication(authentication.BaseAuthentication):
-    """Bot authentication view, used to authenticate data sending bots via API"""
+    """
+    Bot authentication view, used to authenticate data sending bots via API
+    """
 
     def authenticate(self, request):
         bot_name = request.POST.get('bot_id')

--- a/dashboard/core/bots/reports/models.py
+++ b/dashboard/core/bots/reports/models.py
@@ -9,8 +9,6 @@ from dashboard.core.tests.models import Test
 from dashboard.core.metric_units.models import MetricUnit
 
 
-
-
 AGGREGATION_CHOICES = (
     ('None', 'None'),
     ('Total', 'Total'),
@@ -20,10 +18,11 @@ AGGREGATION_CHOICES = (
 
 
 class BotReportDataManger(models.Manager):
-    def create_report(self, bot, browser, browser_version, root_test,
-                      test_path, test_version, aggregation, metric_unit,
-                      metric_unit_prefixed, mean_value, stddev, delta,
-                      is_improvement,prev_result,timestamp=None):
+    def create_report(
+            self, bot, browser, browser_version, root_test,
+            test_path, test_version, aggregation, metric_unit,
+            metric_unit_prefixed, mean_value, stddev, delta,
+            is_improvement,prev_result,timestamp=None):
         bot_report_data = self.create(
             bot=bot, browser=browser, browser_version=browser_version,
             root_test=root_test, test_path=test_path,
@@ -84,9 +83,14 @@ class BotReportData(models.Model):
         super(BotReportData, self).save(*args, **kwargs)
 
     def __unicode__(self):
-        return self.bot.name + ":" + str(self.browser) \
-               + ":" + self.test_version + ":" +\
-               self.test_path + ":" + str(self.mean_value)
+        return '{0}:{1}:{2}:{3}:{4}'.format(
+            self.bot.name, self.browser, self.test_version, self.test_path,
+            self.mean_value)
+
+    def __str__(self):
+        return '{0}:{1}:{2}:{3}:{4}'.format(
+            self.bot.name, self.browser, self.test_version, self.test_path,
+            self.mean_value)
 
     class Meta:
         unique_together = (

--- a/dashboard/core/tests/models.py
+++ b/dashboard/core/tests/models.py
@@ -15,7 +15,7 @@ class Test(models.Model):
     enabled = models.BooleanField(default=False)
 
     def __str__(self):
-        return self.name
+        return self.id
 
     def __unicode__(self):
         return self.id

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -99,11 +99,12 @@
                                     </td>
                                     <td>
                                         <a ng-if="data.test_version==data.prev_results.test_version" popover-trigger="'mouseenter'"
-                                           uib-popover-template="testDetailsPopover.templateUrl" popover-title="test details of both revisions (unchanged)">{{ data.test_path }}
-                                        </a>
+                                           uib-popover-template="testDetailsPopover.templateUrl"
+                                           popover-title="test details of both revisions (unchanged)"
+                                           href="{{ data.plot_link }}">{{ data.test_path }}</a>
                                         <a ng-if="data.test_version != data.prev_results.test_version"  popover-title="test: {{ data.root_test  }}"
-                                           uib-popover="Warning: The test version changed in between the revisions." popover-trigger="'mouseenter'">{{ data.test_path }}
-                                        </a>
+                                           uib-popover="Warning: The test version changed in between the revisions." popover-trigger="'mouseenter'"
+                                           href="{{ data.plot_link }}">{{ data.test_path }}</a>
                                     </td>
                                     <td style="text-align: center">
                                         <span ng-if="data.prev_results.mean_value" popover-trigger="'mouseenter'"
@@ -167,12 +168,11 @@
                                     </td>
                                     <td>
                                         <a ng-if="data.test_version==data.prev_results.test_version" popover-trigger="'mouseenter'"
-                                           uib-popover-template="testDetailsPopover.templateUrl" popover-title="test details of both revisions (unchanged)">{{ data.test_path }}
-                                        </a>
+                                           uib-popover-template="testDetailsPopover.templateUrl" popover-title="test details of both revisions (unchanged)"
+                                           href="{{ data.plot_link }}">{{ data.test_path }}</a>
                                         <a ng-if="data.test_version != data.prev_results.test_version"  popover-title="test: {{ data.root_test  }}"
-                                           uib-popover="Warning: The test version changed in between the revisions." popover-trigger="'mouseenter'">{{ data.test_path }}
-                                        </a>
-
+                                           uib-popover="Warning: The test version changed in between the revisions." popover-trigger="'mouseenter'"
+                                           href="{{ data.plot_link }}">{{ data.test_path }}</a>
                                     </td>
                                     <td style="text-align: center">
                                         <span ng-if="data.prev_results.mean_value" popover-trigger="'mouseenter'"


### PR DESCRIPTION
Clicking on 
![image](https://user-images.githubusercontent.com/4214481/42734960-ac6641b0-884c-11e8-8a68-4a690a84c2db.png) should lead to: 
1. Opening up a new tab on the plot 
2. With the right time selected. 

Unfortunately due to no data, I could only check the 1st one - which works well. I have the timestamps set for the (2)nd to work though - but I cannot guarantee that. 

Also includes a fix to models.py of Tests (use .id instead of .name).  