### PR TITLE
Refactor following RESTful API standards fix(#22, #23, #26)

### DIFF
--- a/dashboard/core/bots/reports/serializers.py
+++ b/dashboard/core/bots/reports/serializers.py
@@ -8,7 +8,7 @@ from dashboard.core.metric_units.serializers import MetricUnitSerializer
 from dashboard.core.tests.serializers import TestListListSerializer
 
 
-class TestPathListSerializer(serializers.Serializer):
+class TestPathsListSerializer(serializers.Serializer):
     test_path = serializers.CharField()
     root_test = serializers.CharField()
     aggregation = serializers.CharField()

--- a/dashboard/core/bots/reports/views.py
+++ b/dashboard/core/bots/reports/views.py
@@ -79,7 +79,7 @@ class ReportDataBaseListViewSerializer(ListAPIView):
             'root_test__in': tests,
             'bot__in': bot,
             'browser__in': browsers,
-            'is_improvement': is_improvement
+            'is_improvement': is_improvement,
         }
 
 
@@ -91,7 +91,8 @@ class BotDataReportImprovementListView(ReportDataBaseListViewSerializer):
         queryset = super(BotDataReportImprovementListView, self).get_queryset()
         filter_params = self.build_filters(is_improvement=True)
         limit = int(self.kwargs.get('limit', 10))
-        return queryset.filter(**filter_params).order_by('-delta')[:limit]
+        return queryset.filter(**filter_params).exclude(
+            prev_result__isnull=True).order_by('-delta')[:limit]
 
 
 class BotDataReportRegressionListView(ReportDataBaseListViewSerializer):
@@ -102,7 +103,8 @@ class BotDataReportRegressionListView(ReportDataBaseListViewSerializer):
         queryset = super(BotDataReportRegressionListView, self).get_queryset()
         filter_params = self.build_filters(is_improvement=False)
         limit = int(self.kwargs.get('limit', 10))
-        return queryset.filter(**filter_params).order_by('-delta')[:limit]
+        return queryset.filter(**filter_params).exclude(
+            prev_result__isnull=True).order_by('-delta')[:limit]
 
 
 class TestPathList(ListAPIView):

--- a/dashboard/core/bots/serializers.py
+++ b/dashboard/core/bots/serializers.py
@@ -13,7 +13,6 @@ class BotsForResultsExistListSerializer(serializers.ModelSerializer):
 
 
 class BotsFullDetailsForResultsExistListSerializer(serializers.ModelSerializer):
-    name = serializers.CharField()
     platform = PlatformListSerializer()
     cpuArchitecture = CPUArchitectureListSerializer()
     gpuType = GPUTypeListSerializer()

--- a/dashboard/core/bots/views.py
+++ b/dashboard/core/bots/views.py
@@ -9,43 +9,24 @@ from dashboard.core.bots.serializers import \
 from rest_framework.generics import ListAPIView
 
 
-class BotsForResultsExistList(ListAPIView):
-    """Fetch just the botname for the plot pages"""
+class BaseBotResultsView(ListAPIView):
     model = Bot
+
+    def get_queryset(self):
+        browser_filter = self.request.query_params.get('browser', None)
+        browser_filter_by = {'pk': browser_filter} if browser_filter else {}
+        browsers = Browser.objects.filter(**browser_filter_by)
+        return Bot.objects.filter(
+            name__in=BotReportData.objects.filter(
+                browser__in=browsers
+            ).distinct('bot').values('bot'),
+            enabled=True
+        )
+
+
+class BotsForResultsExistList(BaseBotResultsView):
     serializer_class = BotsForResultsExistListSerializer
 
-    def get_queryset(self):
-        if self.kwargs.get('browser') == 'all':
-            browser_obj = Browser.objects.all()
-        else:
-            browser_obj = Browser.objects.filter(
-                pk=self.kwargs.get('browser')
-            )
-        return Bot.objects.filter(
-            name__in=BotReportData.objects.filter(
-                browser__in=browser_obj
-            ).distinct('bot').values('bot'),
-            enabled=True
-        )
 
-
-class BotsFullDetailsForResultsExistList(ListAPIView):
-    """Fetch detailed bot fields for the home page"""
-    model = Bot
+class BotsFullDetailsForResultsExistList(BaseBotResultsView):
     serializer_class = BotsFullDetailsForResultsExistListSerializer
-
-    def get_queryset(self):
-        if self.kwargs.get('browser') == 'all':
-            browser_obj = Browser.objects.all()
-        else:
-            browser_obj = Browser.objects.filter(
-                pk=self.kwargs.get('browser')
-            )
-        return Bot.objects.filter(
-            name__in=BotReportData.objects.filter(
-                browser__in=browser_obj
-            ).distinct('bot').values('bot'),
-            enabled=True
-        )
-
-

--- a/dashboard/static/js/app_controllers/dashboard/dashboard.module.js
+++ b/dashboard/static/js/app_controllers/dashboard/dashboard.module.js
@@ -22,16 +22,16 @@ app.controller(
         $sce, $filter
     ) {
     $scope.browsers = browserFactory.query();
-    $scope.bots = botFullDetailsForResultsExistFactory.query({
-        browser: 'all'
-    });
+    $scope.bots = botFullDetailsForResultsExistFactory.query({});
     $scope.platforms = platformFactory.query();
     $scope.gpus = gpuFactory.query();
     $scope.cpus = cpuArchFactory.query();
-    $scope.tests = testsForBrowserAndBotFactory.query({
-        browser: !$scope.selectedBrowser ? 'all' : $scope.selectedBrowser.id,
-        bot: !$scope.selectedBot ? null : $scope.selectedBot.name,
+
+    $scope.tests_query = angular.extend({}, {
+        browser: !$scope.selectedBrowser ? undefined : $scope.selectedBrowser.id,
+        bot: !$scope.selectedBot ? undefined : $scope.selectedBot.name,
     });
+    $scope.tests = testsForBrowserAndBotFactory.query($scope.tests_query);
     $scope.botDetailsPopover = {
         templateUrl: 'bot-template.html'
     };
@@ -46,13 +46,16 @@ app.controller(
     };
     $scope.updateOthersOnBrowserChange = function () {
         //There can be chance of test change
-        $scope.tests = testsForBrowserAndBotFactory.query({
-            browser: !$scope.selectedBrowser ? 'all' : $scope.selectedBrowser.id,
-            bot: !$scope.selectedBot ? null : $scope.selectedBot.name,
-        }, function () {
-            $scope.bots = botFullDetailsForResultsExistFactory.query({
-                browser: !$scope.selectedBrowser ? 'all' : $scope.selectedBrowser.id
+        $scope.tests_query_on_browser = angular.extend({}, {
+            browser: !$scope.selectedBrowser ? undefined : $scope.selectedBrowser.id,
+            bot: !$scope.selectedBot ? undefined : $scope.selectedBot.name,
+        });
+        $scope.tests = testsForBrowserAndBotFactory.query(
+            $scope.tests_query_on_browser, function () {
+            $scope.bot_query = angular.extend({}, {
+               'browser': !$scope.selectedBrowser ? undefined : $scope.selectedBrowser.id
             });
+            $scope.bots = botFullDetailsForResultsExistFactory.query($scope.bot_query);
             $scope.reload();
         });
     };

--- a/dashboard/static/js/app_controllers/dashboard/dashboard.module.js
+++ b/dashboard/static/js/app_controllers/dashboard/dashboard.module.js
@@ -72,39 +72,26 @@ app.controller(
         $scope.noImprovementsFound = false;
         $scope.noRegressionsFound = false;
         $scope.loading = true;
-        $scope.selectedDays = !$scope.selectedDays ? 5 : $scope.selectedDays;
-        $scope.listLimit = !$scope.listLimit? 10 : $scope.listLimit;
-        $scope.selectedBrowserId = !$scope.selectedBrowser ? 'all' : $scope.selectedBrowser.id;
-        $scope.selectedPlatformId = !$scope.selectedPlatform ? 'all' : $scope.selectedPlatform.id;
-        $scope.selectedCPUId = !$scope.selectedCPU ? 'all' : $scope.selectedCPU.id;
-        $scope.selectedGPUId = !$scope.selectedGPU ? 'all' : $scope.selectedGPU.id;
-        $scope.selectedTestId = !$scope.selectedTest ? 'all' : $scope.selectedTest.root_test.id;
-        $scope.selectedBotName = !$scope.selectedBot ? 'all' : $scope.selectedBot.name;
-        $scope.improvement_reports = botReportsImprovementFactory.query({
-            days_since: $scope.selectedDays,
-            platform: $scope.selectedPlatformId,
-            gpu: $scope.selectedGPUId,
-            cpu: $scope.selectedCPUId,
-            browser: $scope.selectedBrowserId,
-            test: $scope.selectedTestId,
-            bot: $scope.selectedBotName,
-            limit: $scope.listLimit
-        }, function (data) {
+        $scope.query_params = angular.extend({}, {
+            browser: !$scope.selectedBrowser ? undefined : $scope.selectedBrowser.id,
+            platform: !$scope.selectedPlatform ? undefined : $scope.selectedPlatform.id,
+            gpu: !$scope.selectedGPU ? undefined : $scope.selectedGPU.id,
+            cpu: !$scope.selectedCPU ? undefined : $scope.selectedCPU.id,
+            test: !$scope.selectedTest ? undefined : $scope.selectedTest.root_test.id,
+            bot: !$scope.selectedBot ? undefined : $scope.selectedBot.name,
+            days_since: !$scope.selectedDays ? 5 : $scope.selectedDays,
+            limit: !$scope.listLimit? 10 : $scope.listLimit
+        });
+
+        $scope.improvement_reports = botReportsImprovementFactory.query(
+            $scope.query_params, function (data) {
             if (data.length == 0) {
                 $scope.noImprovementsFound = true;
             }
             $scope.loading_improvements = false;
         });
-        $scope.regression_reports = botReportsRegressionFactory.query({
-            days_since: $scope.selectedDays,
-            platform: $scope.selectedPlatformId,
-            gpu: $scope.selectedGPUId,
-            cpu: $scope.selectedCPUId,
-            browser: $scope.selectedBrowserId,
-            test: $scope.selectedTestId,
-            bot: $scope.selectedBotName,
-            limit: $scope.listLimit
-        }, function (data) {
+        $scope.regression_reports = botReportsRegressionFactory.query(
+            $scope.query_params, function (data) {
             if (data.length == 0) {
                 $scope.noRegressionsFound = true;
             }

--- a/dashboard/static/js/app_controllers/dashboard/dashboard.services.js
+++ b/dashboard/static/js/app_controllers/dashboard/dashboard.services.js
@@ -14,25 +14,25 @@ app.factory('botReportsRegressionFactory', function($resource) {
 });
 
 app.factory('browserFactory', function($resource) {
-    return $resource('/dash/browser_results_exist');
+    return $resource('/dash/browsers');
 });
 
 app.factory('botFullDetailsForResultsExistFactory', function($resource) {
-    return $resource('/dash/bot_full_details_for_exist/:browser');
+    return $resource('/dash/bot-full-details');
 });
 
 app.factory('platformFactory', function($resource) {
-    return $resource('/dash/platform_results_exist');
+    return $resource('/dash/platforms');
 });
 
 app.factory('gpuFactory', function($resource) {
-    return $resource('/dash/gpu_results_exist');
+    return $resource('/dash/gpus');
 });
 
 app.factory('cpuArchFactory', function($resource) {
-    return $resource('/dash/cpu_results_exist');
+    return $resource('/dash/cpus');
 });
 
 app.factory('testsForBrowserAndBotFactory', function ($resource) {
-    return $resource('/dash/tests_for_browser_bot/:browser/:bot');
+    return $resource('/dash/tests');
 });

--- a/dashboard/static/js/app_controllers/dashboard/dashboard.services.js
+++ b/dashboard/static/js/app_controllers/dashboard/dashboard.services.js
@@ -6,11 +6,11 @@
 app = angular.module('browserperfdash.dashboard.services', ['ngResource']);
 
 app.factory('botReportsImprovementFactory', function($resource) {
-    return $resource('/dash/report/improvement/:days_since/:platform/:gpu/:cpu/:browser/:test/:bot/:limit');
+    return $resource('/dash/report/improvements');
 });
 
 app.factory('botReportsRegressionFactory', function($resource) {
-    return $resource('/dash/report/regression/:days_since/:platform/:gpu/:cpu/:browser/:test/:bot/:limit');
+    return $resource('/dash/report/regressions');
 });
 
 app.factory('browserFactory', function($resource) {

--- a/dashboard/static/js/app_controllers/plot/plot.services.js
+++ b/dashboard/static/js/app_controllers/plot/plot.services.js
@@ -6,25 +6,25 @@
 app = angular.module('browserperfdash.plot.services', ['ngResource']);
 
 app.factory('browserForResultExistFactory', function ($resource) {
-    return $resource('/dash/browser_results_exist');
+    return $resource('/dash/browsers');
 });
 
 app.factory('botForResultsExistFactory', function($resource) {
-    return $resource('/dash/bot_results_exist/:browser');
+    return $resource('/dash/bots');
 });
 
 app.factory('testsForBrowserAndBotFactory', function ($resource) {
-    return $resource('/dash/tests_for_browser_bot/:browser/:bot');
+    return $resource('/dash/tests');
 });
 
 app.factory('subTestPathFactory', function ($resource) {
-    return $resource('/dash/testpath/:browser/:root_test');
+    return $resource('/dash/test-paths');
 });
 
 app.factory('testMetricsOfTestAndSubtestFactory', function ($resource) {
-    return $resource('/dash/test_metrics/:root_test/:subtest');
+    return $resource('/dash/test-metrics/:root_test/:subtest');
 });
 
 app.factory('testResultsForTestAndSubtestFactory', function ($resource) {
-    return $resource('/dash/results_for_subtest/:browser/:root_test/:bot/:subtest/');
+    return $resource('/dash/results');
 });

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -30,10 +30,6 @@ urlpatterns = [
     url(r'^tests_for_browser_bot/(?P<browser>.+)/(?P<bot>.*)$', TestsForBrowserBotList.as_view()),
     url(r'^results_for_subtest/(?P<browser>[-\w]+)/(?P<test>[-\w]+)/(?P<bot>[-\w]+)/(?P<subtest>.+)/$',
         ResultsForSubtestList.as_view()),
-    url(r'^report/improvement/(?P<days_since>\d+)/(?P<platform>[-\w]+)/(?P<gpu>[-\w]+)/'
-        r'(?P<cpu>[-\w]+)/(?P<browser>[-\w]+)/(?P<test>[-\w]+)/(?P<bot>[-\w]+)/(?P<limit>\d+)/$',
-        BotDataReportImprovementListView.as_view()),
-    url(r'^report/regression/(?P<days_since>\d+)/(?P<platform>[-\w]+)/(?P<gpu>[-\w]+)/'
-        r'(?P<cpu>[-\w]+)/(?P<browser>[-\w]+)/(?P<test>[-\w]+)/(?P<bot>[-\w]+)/(?P<limit>\d+)/$',
-        BotDataReportRegressionListView.as_view())
+    url(r'^report/improvements', BotDataReportImprovementListView.as_view()),
+    url(r'^report/regressions', BotDataReportRegressionListView.as_view())
 ]

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -10,8 +10,8 @@ from dashboard.core.metric_units.views import MetricsForTestList
 from dashboard.core.bots.views import BotsForResultsExistList, \
     BotsFullDetailsForResultsExistList
 from dashboard.core.bots.reports.views import TestsForBrowserBotList, \
-    ResultsForSubtestList, BotDataReportImprovementListView, \
-    BotDataReportRegressionListView, TestPathList
+    ResultsForSubTestList, BotDataReportImprovementListView, \
+    BotDataReportRegressionListView, TestPathsList
 
 urlpatterns = [
     url(
@@ -19,17 +19,17 @@ urlpatterns = [
         name='graph_report'
     ),
     url(r'^bot-report', BotReportView.as_view()),
-    url(r'^gpu_results_exist/$', GPUTypeForWhichResultsExistList.as_view()),
-    url(r'^cpu_results_exist/$', CPUArchitectureForWhichResultsExistList.as_view()),
-    url(r'^platform_results_exist/$', PlatformForWhichResultsExistList.as_view()),
-    url(r'^browser_results_exist/$', BrowsersForResultsExistList.as_view()),
-    url(r'^bot_results_exist/(?P<browser>.+)$', BotsForResultsExistList.as_view()),
-    url(r'^bot_full_details_for_exist/(?P<browser>.+)$', BotsFullDetailsForResultsExistList.as_view()),
-    url(r'^testpath/(?P<browser>.+)/(?P<test>.+)$', TestPathList.as_view()),
-    url(r'^test_metrics/(?P<test>[-\w]+)/(?P<subtest>.+)$', MetricsForTestList.as_view()),
-    url(r'^tests_for_browser_bot/(?P<browser>.+)/(?P<bot>.*)$', TestsForBrowserBotList.as_view()),
-    url(r'^results_for_subtest/(?P<browser>[-\w]+)/(?P<test>[-\w]+)/(?P<bot>[-\w]+)/(?P<subtest>.+)/$',
-        ResultsForSubtestList.as_view()),
+    url(r'^gpus$', GPUTypeForWhichResultsExistList.as_view()),
+    url(r'^cpus$', CPUArchitectureForWhichResultsExistList.as_view()),
+    url(r'^platforms$', PlatformForWhichResultsExistList.as_view()),
+    url(r'^browsers$', BrowsersForResultsExistList.as_view()),
+    url(r'^bots$', BotsForResultsExistList.as_view()),
+    url(r'^bot-full-details$', BotsFullDetailsForResultsExistList.as_view()),
+    url(r'^test-paths', TestPathsList.as_view()),
+    url(r'^test-metrics/(?P<test>[-\w]+)/(?P<subtest>.+)$',
+        MetricsForTestList.as_view()),
+    url(r'^tests$', TestsForBrowserBotList.as_view()),
+    url(r'^results$', ResultsForSubTestList.as_view()),
     url(r'^report/improvements', BotDataReportImprovementListView.as_view()),
     url(r'^report/regressions', BotDataReportRegressionListView.as_view())
 ]

--- a/docs/local-settings.py
+++ b/docs/local-settings.py
@@ -29,5 +29,3 @@ DATABASES = {
 STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
-
-


### PR DESCRIPTION
Refactors: 
- Use `filter` params instead of kwargs for all query from Frontend to Backend. Eg: `http://127.0.0.1:8000/dash/results?subtest=mytest&test=maintest` is how it should be - and this is how it looks now. Previously `http://127.0.0.1:8000/dash/results/checjcehck/ares6` . 
- Cut down loads of code duplication and bad logic in `reports/views.py`. Use inheritance whenever necessary
- No more `snake_case` in APIs. It should be always `normal-case`. 
- The POST API from bots is untouched. So this should not break anything. 

Further improvements:
- version API and move all APIs to `api/v1.0/` or something. But this will break bots sending data currently. 

Fix: #23 #26 #22