### PR TITLE
Update docs: remove mysql, add python3.7

### DIFF
--- a/docs/deployment-development.md
+++ b/docs/deployment-development.md
@@ -11,9 +11,11 @@ and with an Apache or Nginx fronted. For that following the guide [deployment-pr
 
 1. Install Debian package dependendencies
 
-```bash
-$ sudo apt-get install python3 python3-pip python3-dev virtualenvwrapper
+Currently, this project works with python3.7 only. To install the appropriate python3.7 packages and dependencies, you need to first add the ["deadsnakes" PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)
 
+```bash
+$ sudo apt-get install python3.7 python3.7-pip python3.7-dev python3.7-distutils virtualenvwrapper
+$ sudo apt-get install postgresql python-psycopg2
 ```
 
 2. Get the files
@@ -42,7 +44,7 @@ Notes:
 
 2. Lets create a virtual environment `dashboard` for our project
 ```bash
-mkvirtualenv -p /usr/bin/python3 dashboard
+mkvirtualenv -p /usr/bin/python3.7 dashboard
 workon dashboard
 ```
 
@@ -54,28 +56,9 @@ cd /path/to/git/checkout/browserperfdash
 pip install -r requirements.txt
 ```
 
-## Setup the database with SQLite
+## Setup the database with PostgreSQL and the app config
 
-
-1. Copy default local_settings.py
-
-```bash
-cp docs/local-settings.py browserperfdash/local_settings.py
-```
-
-2. Setup tables in the DB
-
-```bash
-python manage.py makemigrations
-python manage.py migrate
-python manage.py createsuperuser
-```
-
-3. Collect all the static files for fast serving
-
-```bash
-python manage.py collectstatic
-```
+See [postgres-setup.md](./postgres-setup.md).
 
 ## Run built-in HTTP server
 

--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -48,60 +48,7 @@ pip install -r requirements.txt
 
 ## Setup the database with PostgreSQL and the app config
 
-1. Create a new DB.
-
-```
-$ sudo -i
-$ su - postgres
-$ createdb browserperfdash
-$ psql
-=> CREATE ROLE browserperf_user with password 'browserperf_pass';
-=> GRANT ALL privileges ON DATABASE browserperfdash to browserperf_user;
-=> alter role browserperf_user with LOGIN;
-=> \q
-$ exit
-$ exit
-```
-
-2. Copy default local_settings.py
-
-```bash
-cp docs/local-settings.py browserperfdash/local_settings.py
-```
-
-3. Update the DATABASE type in `browserperfdash/local_settings.py` with this data.
-
-```
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'browserperfdash',
-        'USER': 'browserperf_user',
-        'PASSWORD': 'browserperf_pass',
-        'HOST': 'localhost',
-        'PORT': '',
-    }
-}
-
-
-4. Update other settings in `browserperfdash/local_settings.py`:
-```
-SECRET_KEY = 'Your_Complicated_Key'
-DEBUG = False
-ALLOWED_HOSTS = [<enter_IP_address>, ]
-```
-
-5. Setup initial tables in the DB
-```bash
-python manage.py makemigrations
-python manage.py migrate
-python manage.py createsuperuser
-```
-
-6. Collect all the static files for fast serving
-```bash
-python manage.py collectstatic
-```
+See [postgres-setup.md](./postgres-setup.md).
 
 ## Deploy HTTP server and running the app
 

--- a/docs/postgres-setup.md
+++ b/docs/postgres-setup.md
@@ -1,0 +1,62 @@
+# Setting up the PostgresSQL database with the `browserperfdash`
+
+1. Install Debian package dependendencies
+
+```bash
+$ sudo apt-get install postgresql
+```
+
+2. Create a new DB.
+
+```
+$ sudo -i
+$ su - postgres
+$ createdb browserperfdash
+$ psql
+=> CREATE ROLE browserperf_user with password 'browserperf_pass';
+=> GRANT ALL privileges ON DATABASE browserperfdash to browserperf_user;
+=> alter role browserperf_user with LOGIN;
+=> \q
+$ exit
+$ exit
+```
+
+3. Copy default local_settings.py
+
+```bash
+cp docs/local-settings.py browserperfdash/local_settings.py
+```
+
+4. Update the DATABASE type in `browserperfdash/local_settings.py` with this data.
+
+```
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'browserperfdash',
+        'USER': 'browserperf_user',
+        'PASSWORD': 'browserperf_pass',
+        'HOST': 'localhost',
+        'PORT': '',
+    }
+}
+
+
+5. Update other settings in `browserperfdash/local_settings.py`:
+```
+SECRET_KEY = 'Your_Complicated_Key'
+DEBUG = False
+ALLOWED_HOSTS = [<enter_IP_address>, ]
+```
+
+6. Setup initial tables in the DB
+```bash
+python manage.py makemigrations
+python manage.py migrate
+python manage.py createsuperuser
+```
+
+7. Collect all the static files for fast serving
+```bash
+python manage.py collectstatic
+```


### PR DESCRIPTION
Currently, the browserperfdash app only works with python3.7 and PostgreSQL